### PR TITLE
Make restful_acl check the url params for the parent if it doesn't find it in a nested route style URL

### DIFF
--- a/lib/restful_acl/base.rb
+++ b/lib/restful_acl/base.rb
@@ -26,7 +26,13 @@ module RestfulAcl
     def load_parent_from_uri
       parent_klass = object_class.mom.to_s
       bits         = @uri.split('/')
-      parent_id    = bits.at(bits.index(parent_klass.pluralize) + 1)
+      parent_id    = bits.at(bits.index(parent_klass.pluralize).to_i + 1)
+
+      if parent_id.to_i == 0
+        look_for = /#{parent_klass}_id=(\d+)/
+        @uri.match(look_for)
+        parent_id = $1
+      end
 
       parent_klass.classify.constantize.find(parent_id.to_i)
     end


### PR DESCRIPTION
The impetus behind this was my Rails project that has routes where one controller could be a top level or nested. In this case, in the tests I could not generate the URL as a nested route - instead it only passed the parent_id via normal URL params.

So, I added a check for the parent that does not force us to use nested routes.
